### PR TITLE
feat(Mongo): add param to connect to a mongo host other than localhost

### DIFF
--- a/green-tomato.js
+++ b/green-tomato.js
@@ -109,8 +109,8 @@ exports.serve = function(configParams) {
       },
       parsedHeaders = __.sortObjectDeep(formatHeaders(request.headers));
 
-    if (configParams.regexp && configParams.substitution) {
-      request.url = request.url.replace(configParams.regex.search, configParams.regex.replace);
+    if (configParams.regexp.search && configParams.regexp.replace) {
+      request.url = request.url.replace(configParams.regexp.search, configParams.regexp.replace);
     }
 
     if (!_.isEmpty(parsedHeaders)) {

--- a/green-tomato.js
+++ b/green-tomato.js
@@ -201,7 +201,8 @@ exports.serve = function(configParams) {
   }
 
   function initDB() {
-    Mongoose.connect('mongodb://localhost/green-tomato', {
+    const host = configParams.mongoHost || 'localhost';
+    Mongoose.connect('mongodb://'+ host + '/green-tomato', {
       server: {
         auto_reconnect: true,
         socketOptions : {


### PR DESCRIPTION
This feature allows to connect to different hosts to be able to have mongo allocated in a different machine than the app.